### PR TITLE
Fix browse when matches are more than 1000

### DIFF
--- a/pre.go
+++ b/pre.go
@@ -91,7 +91,7 @@ func searchPres(tx *sql.Tx, q string, offsetInt, countInt int, withNukes bool) (
 	sqlQuery := fmt.Sprintf("SELECT %s FROM %s WHERE MATCH(?) ORDER BY id DESC LIMIT %d,%d", preColumns, sphinxTable, offsetInt, countInt)
 
 	if offsetInt+countInt > defaultMaxMatches {
-		sqlQuery += ", max_matches = " + strconv.Itoa(offsetInt+countInt)
+		sqlQuery += " OPTION max_matches = " + strconv.Itoa(offsetInt+countInt)
 	}
 
 	sqlRows, err := tx.Query(sqlQuery, replacer.Replace(q))
@@ -107,7 +107,7 @@ func latestPres(tx *sql.Tx, offsetInt, countInt int, withNukes bool) ([]preRow, 
 	sqlQuery := fmt.Sprintf("SELECT %s FROM %s ORDER BY id DESC LIMIT %d,%d", preColumns, sphinxTable, offsetInt, countInt)
 
 	if offsetInt+countInt > defaultMaxMatches {
-		sqlQuery += ", max_matches = " + strconv.Itoa(offsetInt+countInt)
+		sqlQuery += " OPTION max_matches = " + strconv.Itoa(offsetInt+countInt)
 	}
 
 	sqlRows, err := tx.Query(sqlQuery)


### PR DESCRIPTION
Since c28ef9aeb1d43c4b938be0b272aa825108d9249e was removed we need to re-add OPTION to the query for max_matches to work again. Closes https://github.com/predbdotovh/pre-api/issues/25
Another option is disabling browse after 50 pages: https://github.com/predbdotovh/website-vuejs/pull/7